### PR TITLE
propagate relabelling for gabriel weights

### DIFF
--- a/libpysal/weights/gabriel.py
+++ b/libpysal/weights/gabriel.py
@@ -59,8 +59,15 @@ class Delaunay(W):
                 " these computations may become unduly slow on large data."
             )
         edges, _ = self._voronoi_edges(coordinates)
+        ids = kwargs.pop("ids")
+        if ids is not None:
+            ids = numpy.asarray(ids)
+            edges = numpy.column_stack((ids[edges[:, 0]], ids[edges[:, 1]]))
+        else:
+            ids = numpy.arange(coordinates.shape[0])
+
         voronoi_neighbors = pandas.DataFrame(edges).groupby(0)[1].apply(list).to_dict()
-        W.__init__(self, voronoi_neighbors, **kwargs)
+        W.__init__(self, voronoi_neighbors, id_order=ids, **kwargs)
 
     def _voronoi_edges(self, coordinates):
         dt = _Delaunay(coordinates)
@@ -171,15 +178,21 @@ class Gabriel(Delaunay):
                 " to accelerate the computation of graphs. Without numba,"
                 " these computations may become unduly slow on large data."
             )
-        edges, _ = self._voronoi_edges(coordinates)
         edges, dt = self._voronoi_edges(coordinates)
         droplist = _filter_gabriel(
             edges,
             dt.points,
         )
-        output = set(map(tuple, edges)).difference(set(droplist))
+        output = numpy.row_stack(list(set(map(tuple, edges)).difference(set(droplist))))
+        ids = kwargs.pop("ids")
+        if ids is not None:
+            ids = numpy.asarray(ids)
+            output = numpy.column_stack((ids[output[:, 0]], ids[output[:, 1]]))
+        else:
+            ids = numpy.arange(coordinates.shape[0])
+
         gabriel_neighbors = pandas.DataFrame(output).groupby(0)[1].apply(list).to_dict()
-        W.__init__(self, gabriel_neighbors, **kwargs)
+        W.__init__(self, gabriel_neighbors, id_order=ids, **kwargs)
 
 
 class Relative_Neighborhood(Delaunay):
@@ -213,15 +226,18 @@ class Relative_Neighborhood(Delaunay):
                 " to accelerate the computation of graphs. Without numba,"
                 " these computations may become unduly slow on large data."
             )
-        edges, _ = self._voronoi_edges(coordinates)
         edges, dt = self._voronoi_edges(coordinates)
         output, dkmax = _filter_relativehood(edges, dt.points, return_dkmax=False)
         row, col, data = zip(*output)
         if binary:
             data = numpy.ones_like(col, dtype=float)
         sp = sparse.csc_matrix((data, (row, col)))  # TODO: faster way than this?
-        tmp = WSP(sp).to_W()
-        W.__init__(self, tmp.neighbors, tmp.weights, **kwargs)
+        ids = kwargs.pop("ids")
+        if ids is None:
+            ids = numpy.arange(sp.shape[0])
+        ids = list(ids)
+        tmp = WSP(sp, id_order=ids).to_W()
+        W.__init__(self, tmp.neighbors, tmp.weights, id_order=ids, **kwargs)
 
 
 #### utilities


### PR DESCRIPTION
Hey,

This solves the test bench for the Delaunay-based graphs, in the sense that ids are retained and keept aligned with the input dataframe. Everything prints the same:

```python
import geopandas
from libpysal import weights, examples
examples.load_example("south.shp") # I can't locate south if I don't load it first, even if it's downloaded?
south = geopandas.read_file(examples.get_path("south.shp"))
south = south.set_geometry(south.centroid)

print(south.FIPS.iloc[:5].tolist())
for ids_ in ('FIPS', south.FIPS):
    wdel = weights.Delaunay.from_dataframe(south, ids=ids_)
    print(wdel.id_order[:5])
    wgab = weights.Gabriel.from_dataframe(south, ids=ids_)
    print(wgab.id_order[:5])
    wrn = weights.Relative_Neighborhood.from_dataframe(south, ids=ids_)
    print(wrn.id_order[:5])
```

*this* is what I mean about "sorting by default." I don't think that, if the user provides `ids='FIPS'`, we should silently return a mis-aligned weights object from `from_dataframe()`. We can do this independently of the parent `W` class. 