### PR TITLE
add common sparse linear algebra operations

### DIFF
--- a/benchmarks/bench_graph.py
+++ b/benchmarks/bench_graph.py
@@ -1,5 +1,6 @@
 import geopandas as gpd
 import numpy as np
+from scipy.sparse import linalg as spla
 from geodatasets import get_path
 
 from libpysal.graph import Graph
@@ -26,6 +27,20 @@ class TimeSuite:
             .sample(self.gdf_str.shape[0] // 5)
             .values,
         }
+        self.sparse_arrays = {
+            k+"_k":v.sparse for k,v in self.graphs.items()
+        }
+        
+        self.sparse_arrays = {
+            "small_int": Graph.build_knn(self.gdf_points, k=10).sparse,
+            "large_int": Graph.build_knn(self.gdf_points, k=500).sparse,
+                'queen' : Graph.build_contiguity(self.gdf).sparse,
+                'rook'  : Graph.build_contiguity(self.gdf).sparse,
+                'delaunay' : Graph.build_triangulation(self.gdf).sparse
+                'gabriel' : Graph.build_triangulation(self.gdf, method='gabriel').sparse
+                'relneigh' : Graph.build_triangulation(self.gdf, method='relative_neighborhoood').sparse
+            }
+        )
 
     def time_queen(self, idx, strict):
         Graph.build_contiguity(
@@ -55,7 +70,7 @@ class TimeSuite:
     time_assign_self_weight.param_names = ["index", "graph_size"]
 
     def time_sparse(self, idx, size):
-        _ = self.graphs[f"{size}_{idx}"].sparse
+        s = self.graphs[f"{size}_{idx}"].sparse
 
     time_sparse.params = (["int", "str"], ["small", "large"])
     time_sparse.param_names = ["index", "graph_size"]
@@ -66,6 +81,32 @@ class TimeSuite:
     time_subgraph.params = (["int", "str"], ["small", "large"])
     time_subgraph.param_names = ["index", "graph_size"]
 
+    def time_inverse(self, graph):
+        s = self.graphs[f"{graph}"].sparse
+        np.linalg.inv(np.eye(s.shape[0]) - .5*s)
+    
+    def time_dense_solve(self, graph):
+        s = self.graphs[f"{graph}"].sparse
+        np.linalg.solve(
+            (np.eye(s.shape[0]) - .5*s).todense(), 
+            np.arange(w.shape[0])
+        )
+
+    def time_sparse_solve(self, graph):
+        s = self.graphs[f"{graph}"].sparse
+        spla.spsolve(
+            sp.eye(s.shape[0]) - .5*s, 
+            np.arange(w.shape[0])
+        )
+
+    def time_dense_slogdet(self, graph):
+        s = self.graphs[f"{graph}"].sparse
+        np.linalg.slogdet(np.eye(s.shape[0]) - .5*s)
+
+    def time_sparse_slogdet(self, graph):
+        s = self.graphs[f"{graph}"].sparse
+        LU = spla.splu(sp.eye(s.shape[0]) - .5*s)
+        np.sum(np.log(np.abs(LU.U.diagonal())))
 
 # class MemSuite:
 #     def mem_list(self):


### PR DESCRIPTION
This adds some common (sparse) linear algebra operations to the test suite. I think this makes sense for us to track here, since decisions about how we trim/taper, `eliminate_zeros()`, or sort data will impact these performance statistics, and these are commonly-used in other areas of the library. Could we integrate these into the suite? 